### PR TITLE
Template format

### DIFF
--- a/Resources/views/V1/debug.html.twig
+++ b/Resources/views/V1/debug.html.twig
@@ -1,5 +1,7 @@
 {% extends debug_template|default('::base.html.twig') %}
 
 {% block body %}
-    {{ dump(data|default(null)) }}
+    {% if data is defined %}
+        {{ dump(data) }}
+    {% endif %}
 {% endblock %}

--- a/Tests/Service/RequestFormatterTest.php
+++ b/Tests/Service/RequestFormatterTest.php
@@ -117,6 +117,12 @@ class RequestFormatterTest extends WebTestCase
                 ),
                 Response::HTTP_CREATED,
             ),
+            array(
+                array(
+                    'data'    => $data = array(),
+                ),
+                Response::HTTP_CREATED,
+            ),
         );
     }
 


### PR DESCRIPTION
Making sure `debug` mode returns `array` for empty array data
